### PR TITLE
fix bug sans unite pas présent dans la BD

### DIFF
--- a/Frontend/src/slice/UniteSlice.jsx
+++ b/Frontend/src/slice/UniteSlice.jsx
@@ -80,7 +80,14 @@ export const uniteSlice = createSlice({
 				return o.nom === "Sans Unité"
 			});
 
-			state.tabUnites.push(sansUnite[0]);
+			if (sansUnite.length !== 0){
+				state.tabUnites.push(sansUnite[0]);
+			}else{ //si sans unité n'est pas dans le base de donnée
+				state.tabUnites.push({
+					nom : "Sans Unité",
+					abrev : ""
+				})
+			}
 
 			action.payload.forEach(unite => {
 				state.tabUnites.push({


### PR DESCRIPTION
Si Sans Unité n'existait pas dans le base de donnée, cela faisait cracher l'application
Maintenant, s'il n'existe pas, ça va le créer automatiquement